### PR TITLE
Fix attribution links and update Intercom configuration

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -88,7 +88,7 @@ Before deploying, you are required on any page you use the Logo API to link back
 Here's an example attribution link to use.
 
 ```html
-<a href="https://logo.dev" alt="Logo API">Logos provided by Logo.dev</a>
+<a href="https://logo.dev" title="Logo API">Logos provided by Logo.dev</a>
 ```
 
 ## Deploying

--- a/migrations/clearbit.mdx
+++ b/migrations/clearbit.mdx
@@ -89,7 +89,7 @@ If you are using an `onerror;` function to detect failed images, it's safe to co
 
     Logo.dev:
     ```html
-    <a href="https://logo.dev" alt="Logo API">Logos provided by Logo.dev</a>
+    <a href="https://logo.dev" title="Logo API">Logos provided by Logo.dev</a>
     ```
 
   </Step>

--- a/mint.json
+++ b/mint.json
@@ -71,7 +71,9 @@
   "analytics": {
     "fathom": {
       "siteId": "UTLFFAEB"
-    },
+    }
+  },
+  "integrations": {
     "intercom": {
       "appId": "tipir4va"
     }


### PR DESCRIPTION
## Summary
- Fixed incorrect HTML attribute usage in Logo.dev attribution links
- Updated Intercom configuration to use proper Mintlify integration field

## Changes
- **Attribution links**: Changed `alt=` to `title=` attribute on `<a>` tags in example code (anchor tags don't support alt attributes)
- **Intercom config**: Moved Intercom settings from `analytics` to `integrations` field in mint.json to match Mintlify's schema requirements

## Test plan
- [x] Verified HTML attribution examples are now valid
- [x] Confirmed mint.json structure is valid JSON
- [x] Checked that Intercom integration uses correct field name

🤖 Generated with [Claude Code](https://claude.ai/code)