### PR TITLE
Remove exposed API key from documentation

### DIFF
--- a/describe/introduction.mdx
+++ b/describe/introduction.mdx
@@ -44,7 +44,7 @@ Expect a single object in the following format. The socials object will return a
     "instagram": "https://www.instagram.com/sweetgreen/",
     "twitter": "https://x.com/sweetgreen"
   },
-  "logo": "https://img.logo.dev/sweetgreen.com?token=live_6a1a28fd-6420-4492-aeb0-b297461d9de2",
+  "logo": "https://img.logo.dev/sweetgreen.com?token=YOUR_TOKEN_HERE",
   "blurhash": "UJPanPxr?Vj[oxazj@od_FWDDoodxrodagWD",
   "colors": [
     { "r": 228, "g": 255, "b": 85, "hex": "#e4ff55" },


### PR DESCRIPTION
## Summary
- Removed exposed live API key from the JSON response example in `/describe/introduction.mdx`
- Replaced with `YOUR_TOKEN_HERE` placeholder to prevent accidental exposure
- Kept API keys in img src attributes as they're needed for displaying example images

## Test plan
- [x] Verified the API key is removed from the JSON example
- [x] Confirmed example images still display correctly with their tokens
- [x] Searched codebase to ensure no other sensitive exposures in text examples

🤖 Generated with [Claude Code](https://claude.ai/code)